### PR TITLE
Fixed the bug if `props` is undefined in recursion

### DIFF
--- a/packages/core/src/utils/serializeNode.tsx
+++ b/packages/core/src/utils/serializeNode.tsx
@@ -31,7 +31,7 @@ export const serializeComp = (
         }
         return serializeComp(child, resolver);
       });
-    } else if (prop.type) {
+    } else if (prop.type && typeof prop.props === 'object') {
       result[key] = serializeComp(prop, resolver);
     } else {
       result[key] = prop;


### PR DESCRIPTION
`props` maybe has a `type` property, but it isn't a craft `UserComponent`, so I recommend a double check of `prop.props`.